### PR TITLE
Add EP /search/worksearchbytitle

### DIFF
--- a/api.http
+++ b/api.http
@@ -4,7 +4,21 @@ Content-Type: text/html
 
 ###
 
-# Login
+# Privado
+GET http://localhost:3009/protegido HTTP/1.1
+Content-Type: application/json, text/html
+# Authorization: 
+# Authorization: mi-token-secreto2
+Authorization: mi-token-secreto
+
+###
+
+# Desde el Controller
+GET http://localhost:3009/api/saludo HTTP/1.1
+Content-Type: text/html
+
+
+###
 POST http://localhost:3009/login/auth HTTP/1.1
 Content-Type: application/json
 #Authorization: mi-token-secreto
@@ -12,10 +26,11 @@ Content-Type: application/json
 {
     "username": "admin",
     "password": "1234",
-    "email": "a@a.com"
+    "email": "admin@localhost"
 }
-
 ###
+
+
 
 # Register a new User
 POST http://localhost:3009/login/register HTTP/1.1
@@ -29,89 +44,14 @@ Content-Type: application/json
 
 ###
 
-# GetAll
-GET http://localhost:3009/books HTTP/1.1
-Content-Type: application/json
-Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTIsInVzZXJuYW1lIjoiYWRtaW4iLCJlbWFpbCI6ImFAYS5jb20iLCJpYXQiOjE3NDQ3MjEwMTYsImV4cCI6MTc4NzkyMTAxNn0.lXf0BDR2vLPPKw3evePB_-XXt9MHyGNFzujnIkk6bzM
-
-###
-
-# GetById
-GET http://localhost:3009/books/2 HTTP/1.1
-Content-Type: application/json
-Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTIsInVzZXJuYW1lIjoiYWRtaW4iLCJlbWFpbCI6ImFAYS5jb20iLCJpYXQiOjE3NDQ3MjEwMTYsImV4cCI6MTc4NzkyMTAxNn0.lXf0BDR2vLPPKw3evePB_-XXt9MHyGNFzujnIkk6bzM
-
-###
-
-# Create
-POST http://localhost:3009/books/create HTTP/1.1
-Content-Type: application/json
-Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTIsInVzZXJuYW1lIjoiYWRtaW4iLCJlbWFpbCI6ImFAYS5jb20iLCJpYXQiOjE3NDQ3MjEwMTYsImV4cCI6MTc4NzkyMTAxNn0.lXf0BDR2vLPPKw3evePB_-XXt9MHyGNFzujnIkk6bzM
-
-# {
-#     "title": "El nombre del viento",
-#     "author": "Patrick Rothfuss",
-#     "image_url": "https://example.com/image.jpg",
-#     "genre": "Fantasía",
-#     "publisher": "Daw Books",
-#     "pages": 662,
-#     "published_date": "2007-03-27",
-#     "sinopsis": "La historia de Kvothe, el Asesino de Reyes",
-#     "reading_time": "20 horas"
-# }
-# {
-#     "title": "El temor de un hombre sabio",
-#     "author": "Patrick Rothfuss",
-#     "image_url": "https://example.com/image2.jpg",
-#     "genre": "Fantasía",
-#     "publisher": "Daw Books",
-#     "pages": 994,
-#     "published_date": "2011-03-01",
-#     "sinopsis": "La continuación de la historia de Kvothe",
-#     "reading_time": "30 horas"
-# }
-
-# {
-#     "title": "Las puertas de piedra",
-#     "author": "Patrick Rothfuss",
-#     "image_url": "https://example.com/image3.jpg",
-#     "genre": "Fantasía",
-#     "publisher": "Daw Books",
-#     "pages": 1000,
-#     "published_date": "2007-10-23",
-#     "sinopsis": "La esperada conclusión de la trilogía de Kvothe",
-#     "reading_time": "TBD"
-# }
+# Login
+POST http://localhost:3009/login/auth HTTP/1.1
+Content-Type: application/json, text/html
 
 {
-    "title": "El nombre del viento",
-    "author": "Patrick Rothfuss",
-    "image_url": "https://example.com/image4.jpg",
-    "genre": "Fantasía",
-    "publisher": "Daw Books",
-    "pages": 662,
-    "published_date": "2007-03-27",
-    "sinopsis": "La historia de Kvothe, el Asesino de Reyes",
-    "reading_time": "20 horas"
-}
-
-###
-
-# Update    
-PUT http://localhost:3009/books/update/4 HTTP/1.1
-Content-Type: application/json
-Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTIsInVzZXJuYW1lIjoiYWRtaW4iLCJlbWFpbCI6ImFAYS5jb20iLCJpYXQiOjE3NDQ3MjEwMTYsImV4cCI6MTc4NzkyMTAxNn0.lXf0BDR2vLPPKw3evePB_-XXt9MHyGNFzujnIkk6bzM
-
-{
-    "title": "Las puertas de piedra - UPDATED",
-    "author": "Patrick Rothfuss - UPDATED",
-    "image_url": "https://example.com/image3.jpg - UPDATED",
-    "genre": "Fantasía - UPDATED",
-    "publisher": "Daw Books - UPDATED",
-    "pages": 1009,
-    "published_date": "2007-10-29",
-    "sinopsis": "La esperada conclusión de la trilogía de Kvothe - UPDATED",
-    "reading_time": "TBD - UPDATED"
+    "username": "Admin",
+    "password": "1234",
+    "email": "admin@localhost"
 }
 
 ###
@@ -120,3 +60,31 @@ Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTIsInVzZXJuYW
 DELETE http://localhost:3009/books/delete/3 HTTP/1.1
 Content-Type: application/json
 Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTIsInVzZXJuYW1lIjoiYWRtaW4iLCJlbWFpbCI6ImFAYS5jb20iLCJpYXQiOjE3NDQ3MjEwMTYsImV4cCI6MTc4NzkyMTAxNn0.lXf0BDR2vLPPKw3evePB_-XXt9MHyGNFzujnIkk6bzM
+
+###
+
+# Search Works by query
+GET http://localhost:3009/search/worksearch?q=picasso&&work_page=1&work_size=1 HTTP/1.1
+Content-Type: application/json
+Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywidXNlcm5hbWUiOiJBZG1pbiIsImVtYWlsIjoiYWRtaW5AbG9jYWxob3N0IiwiaWF0IjoxNzQ1MjMzNjMyLCJleHAiOjE3ODg0MzM2MzJ9.lRaOGa_9WEWkWscER_tyU3pvQ9TBbIrHTvxyilNUkxc
+
+###
+
+# Search specific edition
+GET http://localhost:3009/search/edition/OL13315399M HTTP/1.1
+Content-Type: application/json
+Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywidXNlcm5hbWUiOiJBZG1pbiIsImVtYWlsIjoiYWRtaW5AbG9jYWxob3N0IiwiaWF0IjoxNzQ1MjMzNjMyLCJleHAiOjE3ODg0MzM2MzJ9.lRaOGa_9WEWkWscER_tyU3pvQ9TBbIrHTvxyilNUkxc
+
+###
+
+# Import to db an specific edition
+POST http://localhost:3009/search/import/OL13315399M HTTP/1.1
+Content-Type: application/json
+Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywidXNlcm5hbWUiOiJBZG1pbiIsImVtYWlsIjoiYWRtaW5AbG9jYWxob3N0IiwiaWF0IjoxNzQ1MjMzNjMyLCJleHAiOjE3ODg0MzM2MzJ9.lRaOGa_9WEWkWscER_tyU3pvQ9TBbIrHTvxyilNUkxc
+
+###
+
+# Search Works by title
+GET http://localhost:3009/search/worksearchbytitle?title=quinquela%20martin&work_page=1&work_size=1 HTTP/1.1
+Content-Type: application/json
+Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywidXNlcm5hbWUiOiJBZG1pbiIsImVtYWlsIjoiYWRtaW5AbG9jYWxob3N0IiwiaWF0IjoxNzQ1MjMzNjMyLCJleHAiOjE3ODg0MzM2MzJ9.lRaOGa_9WEWkWscER_tyU3pvQ9TBbIrHTvxyilNUkxc

--- a/src/routes/search.route.ts
+++ b/src/routes/search.route.ts
@@ -3,6 +3,7 @@ import asyncHandler from '../helper/asyncHelper';
 import {
   getEditions,
   getWorks,
+  getWorksByTitle,
   importEdition
 } from '../controllers/search.controller';
 
@@ -10,6 +11,7 @@ const router = Router();
 
 // private
 router.get('/worksearch', asyncHandler(getWorks));
+router.get('/worksearchbytitle', asyncHandler(getWorksByTitle));
 router.get('/edition/:id', asyncHandler(getEditions));
 router.post('/import/:id', asyncHandler(importEdition));
 


### PR DESCRIPTION
## Summary
- EP /search/worksearchbytitle
- finds works from query by title. Parameters: 'fields': fields for include in the response, optional; 'work_page': page from pagination, required; 'work_size': count of works to include for each page, required;
## Task
- Card-19-Busqueda de Libros con Query Params
